### PR TITLE
Fix access level for generateForm method

### DIFF
--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -133,7 +133,7 @@ EOT
     /**
      * Tries to generate forms if they don't exist yet and if we need write operations on entities.
      */
-    private function generateForm($bundle, $entity, $metadata)
+    protected function generateForm($bundle, $entity, $metadata)
     {
         try {
             $this->getFormGenerator()->generate($bundle, $entity, $metadata[0]);


### PR DESCRIPTION
In order to fix 

PHP Fatal error:  Access level to PUGX\GeneratorBundle\Command\GenerateDoctrineCrudCommand::generateForm() must be protected (as in class Sensio\Bundle\GeneratorBundle\Command\GenerateDoctrineCrudCommand) or weaker in /Volumes/Work Data/Projects/OscarRudilla/Store-SandBox/Application/Symfony/vendor/pugx/generator-bundle/PUGX/GeneratorBundle/Command/GenerateDoctrineCrudCommand.php on line 21
